### PR TITLE
bumpversion

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ current_version = 0.1.0
 search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"
 
-[bumpversion:file:sequgen/setup.py]
+[bumpversion:file:setup.py]
 search = version = "{current_version}"
 replace = version = "{new_version}"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,10 @@ current_version = 0.1.0
 search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"
 
+[bumpversion:file:sequgen/setup.py]
+search = version = "{current_version}"
+replace = version = "{new_version}"
+
 [bumpversion:file:CITATION.cff]
 search = version: "{current_version}"
 replace = version: "{new_version}"

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 import os
-from sequgen.__version__ import __version__
-
 from setuptools import setup
 
 here = os.path.abspath(os.path.dirname(__file__))
@@ -10,9 +8,11 @@ here = os.path.abspath(os.path.dirname(__file__))
 with open("README.md") as readme_file:
     readme = readme_file.read()
 
+version = "0.1.0"
+
 setup(
     name="sequgen",
-    version=__version__,
+    version=version,
     description="Create synthetic sequence data.",
     long_description=readme + "\n\n",
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This PR adds setup.py's `version` variable to the list of variables that is managed via `bump2version`, as requested per #46. 