### PR TITLE
api cleanup

### DIFF
--- a/sequgen/deterministic/normal_peak.py
+++ b/sequgen/deterministic/normal_peak.py
@@ -1,12 +1,11 @@
 import numpy
 
 
-def normal_peak(t_predict, location=0.0, stddev=1.0, height=1.0, sign=1):
+def normal_peak(t_predict, location=0.0, stddev=1.0, height=1.0):
     """ """
 
-    assert sign in [-1, 1], "sign should be -1 or 1"
     max_height = 1 / (stddev * numpy.sqrt(2 * numpy.pi))
     z = (t_predict - location) / stddev
     term1 = 1 / (stddev * numpy.sqrt(2 * numpy.pi))
     term2 = numpy.exp((-1 / 2) * numpy.power(z, 2))
-    return sign * height * term1 * term2 / max_height
+    return height * term1 * term2 / max_height

--- a/sequgen/deterministic/sine.py
+++ b/sequgen/deterministic/sine.py
@@ -1,6 +1,6 @@
 import numpy
 
 
-def sine(t_predict, phase_shift=0, amplitude=1.0, wavelength=1.0, average=0.0):
+def sine(t_predict, wavelength, phase_shift=0, amplitude=1.0, average=0.0):
     """ """
     return average + amplitude * numpy.sin(2 * numpy.pi * (t_predict - phase_shift) / wavelength)

--- a/sequgen/deterministic/triangular_peak.py
+++ b/sequgen/deterministic/triangular_peak.py
@@ -3,7 +3,7 @@ import numpy
 
 # pylint: disable=too-many-arguments
 def triangular_peak(t_predict, width_leading=None, width_base_left=None, width_base_right=None, width_trailing=None,
-                    width=1.0, height=1.0, placement=0, sign=1):
+                    width=1.0, height=1.0, location=0, sign=1):
     """Generate a time series containing a triangular peak.
 
     Args:
@@ -29,7 +29,7 @@ def triangular_peak(t_predict, width_leading=None, width_base_left=None, width_b
       height (float):
         The height of the peak.
 
-      placement (float):
+      location (float):
         Where the peak should be placed on the time axis.
 
       sign (float):
@@ -64,6 +64,6 @@ def triangular_peak(t_predict, width_leading=None, width_base_left=None, width_b
         widths.pop(-1)
         y.pop(-1)
 
-    t = placement + numpy.cumsum(widths)
+    t = location + numpy.cumsum(widths)
 
     return sign * numpy.interp(t_predict, t, y)

--- a/tests/deterministic/test_sine.py
+++ b/tests/deterministic/test_sine.py
@@ -7,7 +7,8 @@ from sequgen.deterministic.sine import sine
 def test_with_defaults():
     t_predict = np.linspace(0, 1, 20)
 
-    result = sine(t_predict)
+    wavelength = 1.0
+    result = sine(t_predict, wavelength)
 
     expected = np.array([0.00000000e+00, 3.24699469e-01, 6.14212713e-01, 8.37166478e-01,
                          9.69400266e-01, 9.96584493e-01, 9.15773327e-01, 7.35723911e-01,

--- a/tests/deterministic/test_triangular_peak.py
+++ b/tests/deterministic/test_triangular_peak.py
@@ -17,7 +17,7 @@ def test_with_defaults():
 def test_with_placement():
     t_predict = np.arange(7)
 
-    result = triangular_peak(t_predict, placement=3, width_base_right=2)
+    result = triangular_peak(t_predict, location=3, width_base_right=2)
 
     # TODO expected peak=1 at position 3
     expected = np.array([0., 0., 0., 0.5, 0., 0., 0.])
@@ -27,7 +27,7 @@ def test_with_placement():
 def test_with_base_both_sides():
     t_predict = np.arange(7)
 
-    result = triangular_peak(t_predict, placement=3, width_base_left=2, width_base_right=2)
+    result = triangular_peak(t_predict, location=3, width_base_left=2, width_base_right=2)
 
     # TODO expected peak=1 at position 3
     expected = np.array([0., 0., 0., 0., 0.5, 1., 0.5])


### PR DESCRIPTION
In this PR:

- harmonized naming of poosition/location/placement argument. Refs #54
- removed dign argument from normal peak signature. Refs #60
- Made sine's wavelength argument required. Refs #61 
