### PR TITLE
simplified triangular peak

### DIFF
--- a/sequgen/deterministic/triangular_peak.py
+++ b/sequgen/deterministic/triangular_peak.py
@@ -10,20 +10,23 @@ def triangular_peak(t_predict, width_base_left, width_base_right, location, heig
         Where you want the model to generate predictions.
 
       width_base_left (float):
-        The width of the left part of the triangular peak.
+        The width of the left part of the triangular peak in units of t_predict.
 
       width_base_right (float):
-        The width of the right part of the triangular peak.
+        The width of the right part of the triangular peak in units of t_predict.
 
       height (float):
-        The height of the peak.
+        The height of the peak in user-defined units.
 
       location (float):
-        Where the peak should be placed on the time axis.
+        Where the peak should be placed on the time axis in units of t_predict.
 
     Returns:
-      Numpy array of shape equal to t_predict containing the curve for a triangular peak.
+      Numpy array of shape equal to t_predict containing the curve for a triangular peak in user-defined units.
     """
+
+    assert width_base_left > 0, "width_base_left should be > 0"
+    assert width_base_right > 0, "width_base_right should be > 0"
 
     widths = [0, width_base_left, width_base_right]
     y = [0, height, 0]

--- a/sequgen/deterministic/triangular_peak.py
+++ b/sequgen/deterministic/triangular_peak.py
@@ -2,16 +2,12 @@ import numpy
 
 
 # pylint: disable=too-many-arguments
-def triangular_peak(t_predict, width_leading=None, width_base_left=None, width_base_right=None, width_trailing=None,
-                    width=1.0, height=1.0, location=0, sign=1):
+def triangular_peak(t_predict, width_base_left, width_base_right, location, height=1.0):
     """Generate a time series containing a triangular peak.
 
     Args:
       t_predict (Numpy array):
         Where you want the model to generate predictions.
-
-      width_leading (float):
-        The width of the leading part of the triangular peak, i.e. the part before the peak starts to climb.
 
       width_base_left (float):
         The width of the left part of the triangular peak.
@@ -19,53 +15,19 @@ def triangular_peak(t_predict, width_leading=None, width_base_left=None, width_b
       width_base_right (float):
         The width of the right part of the triangular peak.
 
-      width_trailing (float):
-        The width of the trailing part of the triangular peak, i.e. the part after the peak returns back to
-        the baseline.
-
-      width (float):
-        The width of entire peak (excluding any leading and trailing parts).
-
       height (float):
         The height of the peak.
 
       location (float):
         Where the peak should be placed on the time axis.
 
-      sign (float):
-        Whether the peak should be right side up or upside down.
-
     Returns:
       Numpy array of shape equal to t_predict containing the curve for a triangular peak.
     """
 
-    assert sign in [-1, 1], "sign should be -1 or 1"
+    widths = [0, width_base_left, width_base_right]
+    y = [0, height, 0]
 
-    if width is None:
-        assert width_base_left is not None
-        assert width_base_right is not None
+    t = location - width_base_left + numpy.cumsum(widths)
 
-    if width_base_left is None:
-        assert width is not None
-        assert width_base_right is not None
-        width_base_left = width - width_base_right
-
-    if width_base_right is None:
-        assert width is not None
-        assert width_base_left is not None
-        width_base_right = width - width_base_left
-
-    widths = [0, width_leading, width_base_left, width_base_right, width_trailing]
-    y = [0, 0, height, 0, 0]
-
-    if width_leading is None:
-        widths.pop(1)
-        y.pop(1)
-
-    if width_trailing is None:
-        widths.pop(-1)
-        y.pop(-1)
-
-    t = location + numpy.cumsum(widths)
-
-    return sign * numpy.interp(t_predict, t, y)
+    return numpy.interp(t_predict, t, y)

--- a/tests/deterministic/test_triangular_peak.py
+++ b/tests/deterministic/test_triangular_peak.py
@@ -5,20 +5,23 @@ from sequgen.deterministic.triangular_peak import triangular_peak
 
 def test_with_required_args():
     t_predict = np.linspace(0, 5, 11)
-    result = triangular_peak(t_predict, width_base_left=1.0, width_base_right=1.0, location=1.0)
+    actual = triangular_peak(t_predict, width_base_left=1.0, width_base_right=1.0, location=1.0)
     expected = np.array([0, 0.5, 1.0, 0.5, 0., 0., 0., 0., 0., 0., 0.])
-    assert_almost_equal(result, expected)
+    assert_almost_equal(actual, expected)
 
 
 def test_with_required_args_and_height():
     t_predict = np.linspace(0, 5, 11)
-    result = triangular_peak(t_predict, width_base_left=1.0, width_base_right=1.0, location=1.0, height=2.0)
+    actual = triangular_peak(t_predict, width_base_left=1.0, width_base_right=1.0, location=1.0, height=2.0)
     expected = np.array([0, 1.0, 2.0, 1.0, 0., 0., 0., 0., 0., 0., 0.])
-    assert_almost_equal(result, expected)
+    assert_almost_equal(actual, expected)
 
 
 def test_with_required_args_and_skewness():
     t_predict = np.linspace(0, 5, 11)
-    result = triangular_peak(t_predict, width_base_left=1.0, width_base_right=2.0, location=1.0)
+    location = 1.0
+    actual = triangular_peak(t_predict, width_base_left=1.0, width_base_right=2.0, location=location)
     expected = np.array([0, 0.5, 1.0, 0.75, 0.5, 0.25, 0., 0., 0., 0., 0.])
-    assert_almost_equal(result, expected)
+    default_height = 1.0
+    assert actual[t_predict == location] == default_height, "expected maximum height at t == location"
+    assert_almost_equal(actual, expected)

--- a/tests/deterministic/test_triangular_peak.py
+++ b/tests/deterministic/test_triangular_peak.py
@@ -1,5 +1,6 @@
 import numpy as np
 from numpy.testing import assert_almost_equal
+import pytest
 from sequgen.deterministic.triangular_peak import triangular_peak
 
 
@@ -26,14 +27,44 @@ def test_with_required_args_and_skewness():
     assert actual[t_predict == location] == default_height, "expected maximum height at t == location"
     assert_almost_equal(actual, expected)
 
+
 def test_with_zero_base_left():
-    t_predict = np.linspace(0, 5, 11)  # array([0. , 0.5, 1. , 1.5, 2. , 2.5, 3. , 3.5, 4. , 4.5, 5. ])
-    actual = triangular_peak(t_predict, width_base_left=0.0, width_base_right=2.0, location=1.0)
-    expected = np.array([])
+    t_predict = np.linspace(0, 5, 11)
+    with pytest.raises(AssertionError) as excinfo:
+        triangular_peak(t_predict, width_base_left=0.0, width_base_right=2.0, location=1.0)
+    assert "width_base_left should be > 0" in str(excinfo.value)
+
+
+def test_with_small_base_left_regular_sampling():
+    t_predict = np.linspace(0, 5, 11)
+    actual = triangular_peak(t_predict, width_base_left=1e-9, width_base_right=2.0, location=1.0)
+    expected = np.array([0., 0., 1., 0.75, 0.50, 0.25, 0., 0., 0., 0., 0.])
     assert_almost_equal(actual, expected)
 
-def test_with_zero_base_right():
+
+def test_with_small_base_left_irregular_sampling():
+    t_predict = np.asarray([0, 1-1e-9, 1, 2, 3, 10])
+    actual = triangular_peak(t_predict, width_base_left=1e-9, width_base_right=2.0, location=1.0)
+    expected = np.array([0., 0., 1., 0.50, 0., 0.])
+    assert_almost_equal(actual, expected)
+
+
+def test_with_zero_base_right_regular_sampling():
     t_predict = np.linspace(0, 5, 11)
-    actual = triangular_peak(t_predict, width_base_left=2.0, width_base_right=0.0, location=3.0)
-    expected = np.array([])
+    with pytest.raises(AssertionError) as excinfo:
+        triangular_peak(t_predict, width_base_left=2.0, width_base_right=0.0, location=3.0)
+    assert "width_base_right should be > 0" in str(excinfo.value)
+
+
+def test_with_small_base_right_regular_sampling():
+    t_predict = np.linspace(0, 5, 11)
+    actual = triangular_peak(t_predict, width_base_left=2.0, width_base_right=1e-9, location=3.0)
+    expected = np.array([0., 0., 0., 0.25, 0.50, 0.75, 1.0, 0., 0., 0., 0.])
+    assert_almost_equal(actual, expected)
+
+
+def test_with_small_base_right_irregular_sampling():
+    t_predict = np.asarray([0, 1.0, 2.0, 3.0, 3+1e-9, 10])
+    actual = triangular_peak(t_predict, width_base_left=2.0, width_base_right=1e-9, location=3.0)
+    expected = np.array([0., 0., 0.50, 1.0, 0., 0.])
     assert_almost_equal(actual, expected)

--- a/tests/deterministic/test_triangular_peak.py
+++ b/tests/deterministic/test_triangular_peak.py
@@ -1,34 +1,24 @@
 import numpy as np
 from numpy.testing import assert_almost_equal
-
 from sequgen.deterministic.triangular_peak import triangular_peak
 
 
-def test_with_defaults():
-    t_predict = np.arange(7)
-
-    result = triangular_peak(t_predict, width_base_right=2)
-
-    # TODO expected peak=1 at position 0
-    expected = np.array([0.5, 0., 0., 0., 0., 0., 0.])
+def test_with_required_args():
+    t_predict = np.linspace(0, 5, 11)
+    result = triangular_peak(t_predict, width_base_left=1.0, width_base_right=1.0, location=1.0)
+    expected = np.array([0, 0.5, 1.0, 0.5, 0., 0., 0., 0., 0., 0., 0.])
     assert_almost_equal(result, expected)
 
 
-def test_with_placement():
-    t_predict = np.arange(7)
-
-    result = triangular_peak(t_predict, location=3, width_base_right=2)
-
-    # TODO expected peak=1 at position 3
-    expected = np.array([0., 0., 0., 0.5, 0., 0., 0.])
+def test_with_required_args_and_height():
+    t_predict = np.linspace(0, 5, 11)
+    result = triangular_peak(t_predict, width_base_left=1.0, width_base_right=1.0, location=1.0, height=2.0)
+    expected = np.array([0, 1.0, 2.0, 1.0, 0., 0., 0., 0., 0., 0., 0.])
     assert_almost_equal(result, expected)
 
 
-def test_with_base_both_sides():
-    t_predict = np.arange(7)
-
-    result = triangular_peak(t_predict, location=3, width_base_left=2, width_base_right=2)
-
-    # TODO expected peak=1 at position 3
-    expected = np.array([0., 0., 0., 0., 0.5, 1., 0.5])
+def test_with_required_args_and_skewness():
+    t_predict = np.linspace(0, 5, 11)
+    result = triangular_peak(t_predict, width_base_left=1.0, width_base_right=2.0, location=1.0)
+    expected = np.array([0, 0.5, 1.0, 0.75, 0.5, 0.25, 0., 0., 0., 0., 0.])
     assert_almost_equal(result, expected)

--- a/tests/deterministic/test_triangular_peak.py
+++ b/tests/deterministic/test_triangular_peak.py
@@ -25,3 +25,15 @@ def test_with_required_args_and_skewness():
     default_height = 1.0
     assert actual[t_predict == location] == default_height, "expected maximum height at t == location"
     assert_almost_equal(actual, expected)
+
+def test_with_zero_base_left():
+    t_predict = np.linspace(0, 5, 11)  # array([0. , 0.5, 1. , 1.5, 2. , 2.5, 3. , 3.5, 4. , 4.5, 5. ])
+    actual = triangular_peak(t_predict, width_base_left=0.0, width_base_right=2.0, location=1.0)
+    expected = np.array([])
+    assert_almost_equal(actual, expected)
+
+def test_with_zero_base_right():
+    t_predict = np.linspace(0, 5, 11)
+    actual = triangular_peak(t_predict, width_base_left=2.0, width_base_right=0.0, location=3.0)
+    expected = np.array([])
+    assert_almost_equal(actual, expected)


### PR DESCRIPTION
In this PR I simplified the triangular peak function:
- `location` now refers to location of the peak
- no more leading or trailing widths
- no more asserts
- argument `width` removed
- `width_base_left` and `width_base_right` are now required arguments
- `location` is a required argument
- removed `sign`

Also added new tests

Tests are based on `linspace` (more suited to the expected input type of float)

Refs #47, https://github.com/sequgen/sequgen/issues/61#issuecomment-811050775

