### PR TITLE
Added unit_integral behavior

### DIFF
--- a/sequgen/deterministic/normal_peak.py
+++ b/sequgen/deterministic/normal_peak.py
@@ -1,7 +1,7 @@
 import numpy
 
 
-def normal_peak(t_predict, location=0.0, stddev=1.0, height=1.0):
+def normal_peak(t_predict, location=0.0, stddev=1.0, unit_integral=None, height=None):
     """Generates a peak whose shape is the gaussian distribution function
     Args:
       t_predict:
@@ -12,13 +12,38 @@ def normal_peak(t_predict, location=0.0, stddev=1.0, height=1.0):
         Shape factor that affects the width of the distribution.
       height (float):
         What the peak height should be.
+      unit_integral (bool):
+        If true, area under the curve sums to unity
 
     Returns:
       Numpy array with shape equal to t_predict, containing the y values for the normal peak curve.
     """
 
-    max_height = 1 / (stddev * numpy.sqrt(2 * numpy.pi))
+    if unit_integral is None:
+        # pylint: disable=simplifiable-if-statement
+        if height is None:
+            # user did not specify unit_integral or height
+            unit_integral = True
+        else:
+            # user specified height
+            unit_integral = False
+    elif unit_integral is False:
+        assert height is not None, "You need to specifiy height when unit_integral is False."
+    elif unit_integral is True:
+        assert height is None, "Either define height or set unit_integral to True, but not both."
+    else:
+        raise AssertionError("unit_integral should be None, True, or False")
+
+    # determine scaling parameter
+    if unit_integral is True:
+        scale = 1.0
+    elif unit_integral is False:
+        max_height = 1 / (stddev * numpy.sqrt(2 * numpy.pi))
+        scale = height / max_height
+    else:
+        raise AssertionError("expected unit_integral to be True, False, or None")
+
     z = (t_predict - location) / stddev
     term1 = 1 / (stddev * numpy.sqrt(2 * numpy.pi))
     term2 = numpy.exp((-1 / 2) * numpy.power(z, 2))
-    return height * term1 * term2 / max_height
+    return term1 * term2 * scale

--- a/sequgen/deterministic/normal_peak.py
+++ b/sequgen/deterministic/normal_peak.py
@@ -1,7 +1,7 @@
 import numpy
 
 
-def normal_peak(t_predict, location=0.0, stddev=1.0, unit_integral=None, height=None):
+def normal_peak(t_predict, location, stddev=1.0, unit_integral=None, height=None):
     """Generates a peak whose shape is the gaussian distribution function
     Args:
       t_predict:

--- a/tests/deterministic/test_normal_peak.py
+++ b/tests/deterministic/test_normal_peak.py
@@ -5,7 +5,8 @@ from sequgen.deterministic.normal_peak import normal_peak
 
 def test_without_height_or_unit_integral():
     t_predict = numpy.linspace(-2.5, 2.5, 11)
-    actual = normal_peak(t_predict)
+    location = 0.0
+    actual = normal_peak(t_predict, location)
     expected_height_max = 1 / numpy.sqrt(2 * numpy.pi)
     actual_height_max = actual[t_predict == 0.][0]
     assert actual_height_max == pytest.approx(expected_height_max), "Expected maximum height at t=0"
@@ -13,7 +14,8 @@ def test_without_height_or_unit_integral():
 
 def test_with_unit_integral():
     t_predict = numpy.linspace(-2.5, 2.5, 11)
-    actual = normal_peak(t_predict, unit_integral=True)
+    location = 0.0
+    actual = normal_peak(t_predict, location, unit_integral=True)
     expected_height_max = 1 / numpy.sqrt(2 * numpy.pi)
     actual_height_max = actual[t_predict == 0.][0]
     assert actual_height_max == pytest.approx(expected_height_max), "Expected maximum height at t=0"
@@ -21,20 +23,22 @@ def test_with_unit_integral():
 
 def test_with_height():
     t_predict = numpy.linspace(-2.5, 2.5, 11)
-    actual = normal_peak(t_predict, height=1.0)
+    location = 0.0
+    actual = normal_peak(t_predict, location, height=1.0)
     expected_height_max = 1.0
     actual_height_max = actual[t_predict == 0.][0]
     assert actual_height_max == pytest.approx(expected_height_max), "Expected maximum height at t=0"
 
 
 def test_with_height_and_unit_integral():
+    location = 0.0
     t_predict = numpy.linspace(-2.5, 2.5, 11)
     with pytest.raises(AssertionError) as excinfo:
-        normal_peak(t_predict, height=1.0, unit_integral=True)
+        normal_peak(t_predict, location, height=1.0, unit_integral=True)
     assert "Either define height or set unit_integral to True, but not both." in str(excinfo.value)
 
 
-def test_with_location():
+def test_with_location25():
     t_predict = numpy.linspace(0, 5, 11)
     location = 2.5
     actual = normal_peak(t_predict, location=location)

--- a/tests/deterministic/test_normal_peak.py
+++ b/tests/deterministic/test_normal_peak.py
@@ -12,13 +12,21 @@ def test_without_height_or_unit_integral():
     assert actual_height_max == pytest.approx(expected_height_max), "Expected maximum height at t=0"
 
 
-def test_with_unit_integral():
+def test_with_unit_integral_true():
     t_predict = numpy.linspace(-2.5, 2.5, 11)
     location = 0.0
     actual = normal_peak(t_predict, location, unit_integral=True)
     expected_height_max = 1 / numpy.sqrt(2 * numpy.pi)
     actual_height_max = actual[t_predict == 0.][0]
     assert actual_height_max == pytest.approx(expected_height_max), "Expected maximum height at t=0"
+
+
+def test_with_unit_integral_false():
+    t_predict = numpy.linspace(-2.5, 2.5, 11)
+    location = 0.0
+    with pytest.raises(AssertionError) as excinfo:
+        normal_peak(t_predict, location, unit_integral=False)
+    assert "You need to specifiy height when unit_integral is False." in str(excinfo.value)
 
 
 def test_with_height():
@@ -30,7 +38,7 @@ def test_with_height():
     assert actual_height_max == pytest.approx(expected_height_max), "Expected maximum height at t=0"
 
 
-def test_with_height_and_unit_integral():
+def test_with_height_and_unit_integral_true():
     location = 0.0
     t_predict = numpy.linspace(-2.5, 2.5, 11)
     with pytest.raises(AssertionError) as excinfo:

--- a/tests/deterministic/test_normal_peak.py
+++ b/tests/deterministic/test_normal_peak.py
@@ -29,6 +29,14 @@ def test_with_unit_integral_false():
     assert "You need to specifiy height when unit_integral is False." in str(excinfo.value)
 
 
+def test_with_unit_integral_invalid_value():
+    t_predict = numpy.linspace(-2.5, 2.5, 11)
+    location = 0.0
+    with pytest.raises(AssertionError) as excinfo:
+        normal_peak(t_predict, location, unit_integral="invalid value")
+    assert "unit_integral should be None, True, or False" in str(excinfo.value)
+
+
 def test_with_height():
     t_predict = numpy.linspace(-2.5, 2.5, 11)
     location = 0.0

--- a/tests/deterministic/test_normal_peak.py
+++ b/tests/deterministic/test_normal_peak.py
@@ -1,16 +1,48 @@
-import numpy as np
-from numpy.testing import assert_almost_equal
-
+import pytest
+import numpy
 from sequgen.deterministic.normal_peak import normal_peak
 
 
-def test_with_defaults():
-    t_predict = np.arange(15)
+def test_without_height_or_unit_integral():
+    t_predict = numpy.linspace(-2.5, 2.5, 11)
+    actual = normal_peak(t_predict)
+    expected_height_max = 1 / numpy.sqrt(2 * numpy.pi)
+    actual_height_max = actual[t_predict == 0.][0]
+    assert actual_height_max == pytest.approx(expected_height_max), "Expected maximum height at t=0"
 
-    result = normal_peak(t_predict)
 
-    expected = np.array([1.0000000e+00, 6.0653066e-01, 1.3533528e-01, 1.1108997e-02,
-                         3.3546263e-04, 3.7266532e-06, 1.5229980e-08, 2.2897348e-11,
-                         1.2664166e-14, 2.5767571e-18, 1.9287498e-22, 5.3110922e-27,
-                         5.3801862e-32, 2.0050088e-37, 2.7487850e-43])
-    assert_almost_equal(result, expected)
+def test_with_unit_integral():
+    t_predict = numpy.linspace(-2.5, 2.5, 11)
+    actual = normal_peak(t_predict, unit_integral=True)
+    expected_height_max = 1 / numpy.sqrt(2 * numpy.pi)
+    actual_height_max = actual[t_predict == 0.][0]
+    assert actual_height_max == pytest.approx(expected_height_max), "Expected maximum height at t=0"
+
+
+def test_with_height():
+    t_predict = numpy.linspace(-2.5, 2.5, 11)
+    actual = normal_peak(t_predict, height=1.0)
+    expected_height_max = 1.0
+    actual_height_max = actual[t_predict == 0.][0]
+    assert actual_height_max == pytest.approx(expected_height_max), "Expected maximum height at t=0"
+
+
+def test_with_height_and_unit_integral():
+    t_predict = numpy.linspace(-2.5, 2.5, 11)
+    with pytest.raises(AssertionError) as excinfo:
+        normal_peak(t_predict, height=1.0, unit_integral=True)
+    assert "Either define height or set unit_integral to True, but not both." in str(excinfo.value)
+
+
+def test_with_location():
+    t_predict = numpy.linspace(0, 5, 11)
+    location = 2.5
+    actual = normal_peak(t_predict, location=location)
+    expected_height_max = 1 / numpy.sqrt(2 * numpy.pi)
+    actual_height_max = actual[t_predict == location][0]
+    assert actual_height_max == pytest.approx(expected_height_max), "Expected maximum height at t=2.5"
+    expected = numpy.array([0.0175, 0.0539, 0.1295, 0.2419, 0.3520, 0.3989,
+                            0.3520, 0.2419, 0.1295, 0.05399, 0.0175])
+    assert actual == pytest.approx(expected, abs=0.0001)
+
+


### PR DESCRIPTION
In this PR:

- added unit_integral behavior Refs #35
- calling normal peak is now more convenient for user
- `location` is now required parameter
- updated tests
