### PR TITLE
Fix `ModuleNotFoundError: No module named 'sequgen'` on readthedocs b…

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,4 @@
+
+python:
+    version: 3.8
+    pip_install: true


### PR DESCRIPTION
…uild

Fixes #40 

Rendered docs available at https://sequgen.readthedocs.io/en/40-rtd/index.html
