### PR TITLE
Release 0.2.0 issues

### DIFF
--- a/README.dev.md
+++ b/README.dev.md
@@ -101,7 +101,7 @@ bump2version minor
 1.  Update the `CHANGELOG.md`
 2.  Verify that the information in `CITATION.cff` is correct, and that
     `.zenodo.json` contains equivalent data
-3.  Make sure the version has been updated.
+3.  Update the version with `bump2version minor` and verify that this has worked correctly
 4.  Run the unit tests with `pytest tests/`
 
 ### PyPI
@@ -149,7 +149,7 @@ which sequgen
 python3 -m pip uninstall sequgen
 
 # install in user space from test pypi instance:
-python3 -m pip -v install --user --no-cache-dir \
+python3 -m pip -v install --no-cache-dir \
 --index-url https://test.pypi.org/simple/ \
 --extra-index-url https://pypi.org/simple sequgen
 ```

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ setup(
     ],
     test_suite="tests",
     install_requires=[
-        "matplotlib >= 3.3",
         "numpy >= 1.19"
     ],
     setup_requires=[


### PR DESCRIPTION
While preparing release 0.2.0, we found three issues in the documentation and code:

1. `bumpversion` was not mentioned in the [release preparation instructions](https://github.com/sequgen/sequgen/blob/main/README.dev.md#preparation) (added)
2. in the command for [testing test pypi upload](https://github.com/sequgen/sequgen/blob/main/README.dev.md#pypi) the part `--user` caused an error (part removed)
3. `matplotlib` is not a necessary requirement because sequgen does no plotting (requirement removed)

These three issues have been fixed in this PR.